### PR TITLE
Fix search prestige issues

### DIFF
--- a/src/app/enemies/search/search.component.ts
+++ b/src/app/enemies/search/search.component.ts
@@ -54,7 +54,9 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     this.moreSearch =
       AllSkillEffects.SEARCH_CRY.numOwned > 0 ||
       AllSkillEffects.SEARCH_METAL.numOwned > 0 ||
-      AllSkillEffects.SEARCH_HAB.numOwned > 0;
+      AllSkillEffects.SEARCH_HAB.numOwned > 0 ||
+      AllSkillEffects.SEARCH_HAB2.numOwned > 0 ||
+      AllSkillEffects.SEARCH_RANDOM.numOwned > 0;
 
     this.metal = AllSkillEffects.SEARCH_METAL.numOwned > 0;
     this.cry = AllSkillEffects.SEARCH_CRY.numOwned > 0;

--- a/src/app/model/prestige/allSkillEffects.ts
+++ b/src/app/model/prestige/allSkillEffects.ts
@@ -372,7 +372,7 @@ export class AllSkillEffects {
     };
     AllSkillEffects.SEARCH_RANDOM.name = "Prestige search random";
     resMan.searchX1.productionMultiplier.additiveBonus.push(
-      new Bonus(AllSkillEffects.SEARCH_HAB2, 0.5, true)
+      new Bonus(AllSkillEffects.SEARCH_RANDOM, 0.5, true)
     );
 
     AllSkillEffects.DOUBLE_DISTRICTS.getDescription = (num = 1) => {


### PR DESCRIPTION
#### Issue 1:
When getting `"randomized districts"` or `"even more habitable space"` without another search prestige, both icon don't show up.

#### Cause:
`"moreSearch"` doesn't check those two skill.
https://github.com/scorzy/IdleSpace/blob/d9a1ba8b280a9b4a0895d663a57901bca23a2b39/src/app/enemies/search/search.component.ts#L54-L57

____

#### Issue 2:
`"randomized districts"` shows up on the info page as `"Prestige search habitable space 2"`.

#### Cause:
`"SEARCH_HAB2"` was added instead of `"SEARCH_RANDOM"`
https://github.com/scorzy/IdleSpace/blob/22a2dea06bc9157d9385bf06738c8dd4c50e7818/src/app/model/prestige/allSkillEffects.ts#L364-L376

![image](https://user-images.githubusercontent.com/4752645/59155973-7d308400-8ac6-11e9-91a7-9ee5f67d85a3.png)


