### PR TITLE
Optimization and balance changes

### DIFF
--- a/src/app/battle.service.ts
+++ b/src/app/battle.service.ts
@@ -73,7 +73,8 @@ export class BattleService {
         });
         const qta = MyFromDecimal(ds.quantity).toNumber();
         for (let num = 0; num < qta; num++) {
-          ships.push(ship.getCopy());
+          let copy = ship.getCopy();
+          copy.fleetIndex = ships.push(copy)-1;
         }
       });
     });
@@ -85,151 +86,150 @@ export class BattleService {
     //  Up to 5 rounds
     const battleFleets = [playerShips, enemyShip];
     //  for each round
+    //   Ships are assumed to all attack at the same time
     for (let round = 0; round < 5; round++) {
       //  for both player and enemy fleets
       for (let num = 0; num < 2; num++) {
         const ships = battleFleets[num];
         const targets = battleFleets[(num + 1) % 2];
-        if (targets.length < 1 || ships.length < 1) break;
-        let defenders = targets.filter(s => s.class === "3");
+
+        // Create a copy of targets so it's simpler to implement
+        const all = [];
+        const defenders = [];
+        const ground = [];
+
+        for (const target of targets) {
+          all.push(target);
+          if (target.class === "3")
+            defenders.push(target);
+
+          if (target.isDefense)
+            ground.push(target);
+        }
+
         // console.log(defenders.length);
-        let n = 0;
         for (const ship of ships) {
-          n++;
+          let availableTargets = all;
 
-          let availableTargets = targets;
-
-          //  80% chance of hitting a defender
-          if (
-            ship.class !== "2" &&
+          // Bomber can only hit grounded target
+          if (ship.class === "2") {
+            // skip early if there no ground unit
+            if (ground.length === 0) continue;
+            availableTargets = ground;
+          } else if (
+            //  80% chance of hitting a defender
             defenders.length > 0 &&
             Math.random() < 0.8
           ) {
             availableTargets = defenders;
           }
 
-          switch (ship.class) {
-            case "1": // Fighter
-              availableTargets = availableTargets.filter(t => t.armor.gt(0));
-              if (availableTargets.length === 0) availableTargets = targets;
-              break;
-            case "2": // Bomber
-              availableTargets = targets.filter(
-                t => t.isDefense && t.armor.gt(0)
-              );
-              break;
-          }
+          for (const weapon of ship.modules) {
+            const target = availableTargets[Math.floor(Math.random() * availableTargets.length)];
 
-          ship.modules.forEach(weapon => {
-            const target =
-              availableTargets[Math.floor(Math.random() * availableTargets.length)];
-            if (target) {
-              let damageToDo = weapon.damage;
-              //  Damage to shield
-              if (target.shield.gt(0)) {
-                const shieldPercent = weapon.shieldPercent / 100;
-                let maxShieldDamage = damageToDo.times(shieldPercent);
-                maxShieldDamage = maxShieldDamage
-                  .minus(target.shieldReduction)
-                  .max(0);
-                //  Skip if damage <0.1% shield
-                if (maxShieldDamage.gte(target.shield.div(1000))) {
-                  target.shield = target.shield.minus(maxShieldDamage);
-                  // tslint:disable-next-line:prefer-conditional-expression
-                  if (target.shield.lt(0)) {
-                    damageToDo = Decimal.abs(
-                      target.shield.minus(target.shieldReduction)
-                    ).div(shieldPercent);
-                    // console.log(damageToDo.toNumber());
-                  } else {
-                    damageToDo = new Decimal(0);
-                  }
-                } else {
-                  damageToDo = new Decimal(0);
-                }
-              }
-              //  Damage to Armor
-              if (damageToDo.gt(0)) {
-                let maxArmorDamage = damageToDo.times(weapon.armorPercent / 100);
-                maxArmorDamage = maxArmorDamage
-                  .minus(target.armorReduction)
-                  .max(0);
-                //  Skip if damage < 0.1% armor
-                if (maxArmorDamage.gte(target.armor.div(1000))) {
-                  target.armor = target.armor.minus(maxArmorDamage);
-                  //  Check explosion
-                  // console.log(
-                  //   target.armor.div(target.originalArmor).toNumber() +
-                  //     " - " +
-                  //     target.explosionLevel
-                  // );
-                  if (
-                    target.armor.gt(0) &&
-                    target.armor.div(target.originalArmor).toNumber() <
-                      target.explosionLevel
-                  ) {
-                    const prob =
-                      1 -
-                      target.armor
-                        .div(target.originalArmor.times(target.explosionLevel))
-                        .toNumber();
-                    // console.log(
-                    //   "Expl:" +
-                    //     target.armor.toNumber() +
-                    //     " " +
-                    //     target.originalArmor.toNumber() +
-                    //     " " +
-                    //     target.explosionLevel +
-                    //     " " +
-                    //     prob
-                    // );
-                    if (Math.random() < prob) {
-                      //  Explode
-                      target.armor = new Decimal(-1);
-                    }
-                  }
-                }
-              }
-              //  Remove defenders
-              if (target.armor.lt(0)) {
-                defenders = defenders.filter(d => d.armor.gt(0));
-              }
+            // targeted dead ship, consider attack as missed
+            if (target.armor.lt(0)) continue
+
+            let damageToDo = weapon.damage;
+            //  Damage to shield
+            if (target.shield.gt(0)) {
+              const shieldPercent = weapon.shieldPercent / 100;
+              let maxShieldDamage = damageToDo.times(shieldPercent)
+                .minus(target.shieldReduction)
+                .max(0);
+
+              //  Skip if damage <0.1% shield
+              if (maxShieldDamage.lt(target.shield.div(1000))) continue
+
+              target.shield = target.shield.minus(maxShieldDamage);
+
+              if (target.shield.gte(0)) continue
+
+              damageToDo = target.shield.minus(target.shieldReduction).abs().div(shieldPercent);
+              // console.log(damageToDo.toNumber());
+
             }
-          });
+            //  Damage to Armor
+            if (damageToDo.gt(0)) {
+              let maxArmorDamage = damageToDo.times(weapon.armorPercent / 100)
+                .minus(target.armorReduction)
+                .max(0);
 
-          if (n % 10 === 0 && targets.findIndex(t => t.armor.gt(0)) < 0) {
+              //  Skip if damage < 0.1% armor
+              if (maxArmorDamage.lt(target.armor.div(1000))) continue
+
+              target.armor = target.armor.minus(maxArmorDamage);
+              //  Check explosion
+              // console.log(
+              //   target.armor.div(target.originalArmor).toNumber() +
+              //     " - " +
+              //     target.explosionLevel
+              // );
+              if (
+                target.armor.gt(0) &&
+                target.armor.div(target.originalArmor).toNumber() <
+                  target.explosionLevel
+              ) {
+                const prob =
+                  1 -
+                  target.armor
+                    .div(target.originalArmor.times(target.explosionLevel))
+                    .toNumber();
+                // console.log(
+                //   "Expl:" +
+                //     target.armor.toNumber() +
+                //     " " +
+                //     target.originalArmor.toNumber() +
+                //     " " +
+                //     target.explosionLevel +
+                //     " " +
+                //     prob
+                // );
+                if (Math.random() < prob) {
+                  //  Explode
+                  target.armor.fromNumber(-1);
+                }
+              }
+
+              //  Remove dead ship
+              if (target.armor.lt(0)) {
+                target.free();
+
+                let last_target = targets.pop();
+                // Modify target array inplace without shifting every item (optimization)
+                if (target !== last_target) {
+                  // Take the last target in array and put it where the target was.
+                  last_target.fleetIndex = target.fleetIndex;
+                  targets[target.fleetIndex] = last_target;
+                }
+              }
+
+            }
+          };
+
+          // If all target are dead, skip the rest of the ships in fleet.
+          if (targets.length === 0 ) {
             // console.log("break");
             break;
           }
         }
       }
-      //  Remove death ships
-      for (let num = 0; num < 2; num++) {
-        const ships = battleFleets[num];
-        const aliveShips = new Array<Ship>();
-        for (const ship of ships) {
-          if (ship.armor.gt(0)) {
-            aliveShips.push(ship);
-          } else {
-            ship.free();
-          }
-        }
-        battleFleets[num] = aliveShips;
-      }
+
+      // If one of the fleet is dead
+      if (battleFleets[0].length < 1 || battleFleets[1].length < 1) break;
 
       //  Recharge shields
-      for (let num = 0; num < 2; num++) {
-        const ships = battleFleets[num];
+      for (const ships of battleFleets) {
         let totalCharge = ships
-          .map(s => s.shieldCharger)
-          .reduce((p, c) => p.plus(c), new Decimal(0));
-        const sorted = ships
-          .filter(s => s.shield.gt(0))
-          .sort((a, b) =>
-            a.shield.div(a.originalShield).cmp(b.shield.div(b.originalShield))
-          );
+          .reduce((p, s) => p.plus(s.shieldCharger), new Decimal(0));
         // console.log("total charge: " + totalCharge.toNumber());
         if (totalCharge.gt(0)) {
+          const sorted = ships
+            .filter(s => s.shield.gt(0))
+            .sort((a, b) =>
+              a.shield.div(a.originalShield).cmp(b.shield.div(b.originalShield))
+            );
+
           for (const ship of sorted) {
             const missing = ship.originalShield
               .minus(ship.shield)
@@ -243,8 +243,6 @@ export class BattleService {
         }
       }
 
-      [playerShips, enemyShip] = battleFleets; // Update ships variable to new array
-
       //  Regenerate shields
       // playerShips
       //   .concat(enemyShip)
@@ -252,8 +250,6 @@ export class BattleService {
       //   .forEach(s => {
       //     s.shield = new Decimal(s.originalShield);
       //   });
-
-      if (playerShips.length === 0 || enemyShip.length === 0) break;
     }
     //#endregion
     //#region Return
@@ -267,9 +263,13 @@ export class BattleService {
     retArr.forEach(arr => {
       const fleetCount = {};
 
+      arr[0].forEach(fl => {
+        fleetCount[fl.id] = 0;
+      })
+
       // Count and free the ships object
       for (const ship of arr[1]) {
-        fleetCount[ship.id] = fleetCount[ship.id] ? fleetCount[ship.id] + 1 : 1;
+        fleetCount[ship.id]+=1;
         ship.free();
       }
 

--- a/src/app/workers/ship.ts
+++ b/src/app/workers/ship.ts
@@ -1,5 +1,7 @@
 class Ship {
   private static Ships = new Array<Ship>();
+  private active: Boolean;
+  fleetIndex: number;
   id: string;
   armor: Decimal = new Decimal();
   originalArmor: Decimal;
@@ -19,6 +21,7 @@ class Ship {
 
   getCopy(): Ship {
     const ret = Ship.Ships.pop() || new Ship();
+    ret.active = true;
     ret.id = this.id;
     ret.armor.fromDecimal(this.armor);
     ret.shield.fromDecimal(this.shield);
@@ -38,7 +41,10 @@ class Ship {
 
   free(): void {
     // Reuse object to prevent gc
-    Ship.Ships.push(this);
+    if (this.active === true){
+        this.active = false;
+        Ship.Ships.push(this);
+    }
   }
 }
 


### PR DESCRIPTION
Remove filter usage from 'hot code'.

Change battle from ship turn by turn to round base.
* This nerf no armor/shield ships so they don't simply overpower everything and have no lost if all target get destroyed by allowing the enemy a chance to attack.
* Make defenders more useful as a decoy by allowing targeting ship that gotten destroyed in the same round , ie: a wasted attack. (mostly cause it lag too much by trying to remove dead ships)