### PR TITLE
Fixes icon getting cut off when collapsed

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,6 +21,11 @@ clr-icon {
   width: 24px;
 }
 
+/* Fixes icon getting cut off when collapsed #37 */
+.clr-vertical-nav.is-collapsed .nav-icon {
+    margin-left: 0 !important;
+}
+
 ::-webkit-scrollbar {
   height: 0.2rem;
   width: 0.2rem;


### PR DESCRIPTION
Fixes #37

Description:
When collapsing nav, icon get cut off/isn't centered.

Cause:
css in third party library (clr) which adds a margin.
```
    .main-container:not([class*='open-overflow-menu']):not([class*='open-hamburger-menu']) .clr-vertical-nav.is-collapsed .nav-icon {
      margin: 0;
      margin-left: 0.666667rem; }
```

Solution:
Add a css that override that margin-left.